### PR TITLE
Add current session route

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -63,5 +63,5 @@ setup()
     const sessionsRouter = await getSessionsRouter();
     app.use('/issuer', issuerRouter);
     app.use('/verifier', verifierRouter);
-    app.use('/sessions', sessionsRouter)
+    app.use('/sessions', sessionsRouter);
   });

--- a/app.ts
+++ b/app.ts
@@ -7,6 +7,7 @@ import { SDJwtVCService } from './services/sd-jwt-vc';
 import { VCVerifier } from './services/verifier';
 import { getIssuerRouter } from './routers/issuer';
 import { getVerifierRouter } from './routers/verifier';
+import { getSessionsRouter } from './routers/sessions';
 import { startCleanupCron } from './utils/cleanup-cron';
 import env from './utils/environment';
 import { logger } from './utils/logger';
@@ -59,6 +60,8 @@ setup()
     startCleanupCron({ issuerService: issuer, verifierService: verifier });
     const issuerRouter = await getIssuerRouter(issuer);
     const verifierRouter = await getVerifierRouter(verifier);
+    const sessionsRouter = await getSessionsRouter();
     app.use('/issuer', issuerRouter);
     app.use('/verifier', verifierRouter);
+    app.use('/sessions', sessionsRouter)
   });

--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -3,7 +3,6 @@ import env from '../utils/environment';
 import {
   getCredentialDisplay,
   getCredentialMetadataClaims,
-  getOldCredentialClaims,
   getSessionInfoForCredentialOfferToken,
   getVctClaims,
   getVctDisplay,

--- a/routers/sessions.ts
+++ b/routers/sessions.ts
@@ -1,60 +1,62 @@
 import Router from 'express-promise-router';
-import { selectAccountBySession, deleteSession } from '../utils/credential-format';
+import {
+  selectAccountBySession,
+  deleteSession,
+} from '../utils/credential-format';
 
 export async function getSessionsRouter() {
   const router = Router();
 
   router.get('/current', async function (req, res) {
     const sessionUri = req.get('mu-session-id');
-    if (!sessionUri)
-      throw new Error("Session header is missing");
+    if (!sessionUri) throw new Error('Session header is missing');
 
-    const { groupId, accountId, sessionId, roles } = await selectAccountBySession(sessionUri);
+    const { groupId, accountId, sessionId, roles } =
+      await selectAccountBySession(sessionUri);
 
     res.send({
       links: {
-        self: `https://${req.host}${req.baseUrl}`
+        self: `https://${req.host}${req.baseUrl}`,
       },
       data: {
         type: 'sessions',
         id: sessionId,
         attributes: {
-          roles
-        }
+          roles,
+        },
       },
       relationships: {
         account: {
           links: {
-              related: `/accounts/${accountId}`
+            related: `/accounts/${accountId}`,
           },
           data: {
             type: 'accounts',
-            id: accountId
-          }
+            id: accountId,
+          },
         },
         group: {
           links: {
-            related: `/groups/${groupId}`
+            related: `/groups/${groupId}`,
           },
           data: {
             type: 'groups',
-            id: groupId
-          }
-        }
-      }
+            id: groupId,
+          },
+        },
+      },
     });
   });
 
   router.delete('/current', async function (req, res) {
     const sessionUri = req.get('mu-session-id');
-    if (!sessionUri)
-      throw new Error("Session header is missing")
+    if (!sessionUri) throw new Error('Session header is missing');
 
-    const { account } = await selectAccountBySession(sessionUri)
-    await deleteSession(account)
-    res.append('mu-auth-allowed-groups', 'CLEAR')
-    res.sendStatus(204)
+    const { account } = await selectAccountBySession(sessionUri);
+    await deleteSession(account);
+    res.append('mu-auth-allowed-groups', 'CLEAR');
+    res.sendStatus(204);
   });
 
   return router;
-};
+}

--- a/routers/sessions.ts
+++ b/routers/sessions.ts
@@ -17,16 +17,16 @@ export async function getSessionsRouter() {
         id: sessionId,
         attributes: {
           roles
-        },
-        relationships: {
-          account: {
-            links: {
-               related: `/accounts/${accountId}`
-            },
-            data: {
-              type: 'accounts',
-              id: accountId
-            }
+        }
+      },
+      relationships: {
+        account: {
+          links: {
+              related: `/accounts/${accountId}`
+          },
+          data: {
+            type: 'accounts',
+            id: accountId
           }
         },
         group: {

--- a/routers/sessions.ts
+++ b/routers/sessions.ts
@@ -1,0 +1,46 @@
+import Router from 'express-promise-router';
+import { selectAccountBySession } from '../utils/credential-format';
+
+export async function getSessionsRouter() {
+  const router = Router();
+
+  router.get('/current', async function (req, res) {
+    const sessionUri = req.get('mu-session-id') as string;
+    const { groupId, accountId, sessionId, roles } = await selectAccountBySession(sessionUri)
+
+    res.send({
+      links: {
+        self: `https://${req.host}${req.baseUrl}`
+      },
+      data: {
+        type: 'sessions',
+        id: sessionId,
+        attributes: {
+          roles
+        },
+        relationships: {
+          account: {
+            links: {
+               related: `/accounts/${accountId}`
+            },
+            data: {
+              type: 'accounts',
+              id: accountId
+            }
+          }
+        },
+        group: {
+          links: {
+            related: `/groups/${groupId}`
+          },
+          data: {
+            type: 'groups',
+            id: groupId
+          }
+        }
+      }
+    });
+  });
+
+  return router;
+}

--- a/utils/credential-format.ts
+++ b/utils/credential-format.ts
@@ -254,7 +254,7 @@ export const updateSessionWithCredentialInfo = async (
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX session: <http://mu.semte.ch/vocabularies/ext/session/>
+      PREFIX session: <http://mu.semte.ch/vocabularies/session/>
 
       INSERT DATA {
         GRAPH ${sparqlEscapeUri(env.SESSION_GRAPH)} {

--- a/utils/credential-format.ts
+++ b/utils/credential-format.ts
@@ -260,7 +260,7 @@ export const updateSessionWithCredentialInfo = async (
         GRAPH ${sparqlEscapeUri(env.SESSION_GRAPH)} {
           ${sparqlEscapeUri(session)} mu:uuid ${sparqlEscapeString(uuid())} ;
             session:account ${sparqlEscapeUri(accountUri)} ;
-            ext:sessionGroup ${sparqlEscapeString(group)} ;
+            ext:sessionGroup ${sparqlEscapeUri(group)} ;
             ext:sessionRole ${safeRolesString} ;
             dct:modified ${sparqlEscapeDateTime(new Date())} .
         }

--- a/utils/credential-format.ts
+++ b/utils/credential-format.ts
@@ -324,9 +324,19 @@ async function getGroupId(groupUri: string) {
   return result.results.bindings[0].groupId.value;
 }
 
-export async function selectAccountBySession(sessionUri: string): Promise<{account: string, sessionId: string, accountId: string, groupId: string, roles: string[]}> {
-
-  const accountGraphPrefix = env.ACCOUNT_GRAPH_TEMPLATE.replace('{{groupId}}', '');
+export async function selectAccountBySession(
+  sessionUri: string,
+): Promise<{
+  account: string;
+  sessionId: string;
+  accountId: string;
+  groupId: string;
+  roles: string[];
+}> {
+  const accountGraphPrefix = env.ACCOUNT_GRAPH_TEMPLATE.replace(
+    '{{groupId}}',
+    '',
+  );
 
   const result = await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -360,8 +370,8 @@ export async function selectAccountBySession(sessionUri: string): Promise<{accou
     sessionId: binding.session_uuid?.value,
     groupId: binding.group_uuid?.value,
     accountId: binding.account_uuid?.value,
-    roles: binding.roles.value.split(",")
-  }
+    roles: binding.roles.value.split(','),
+  };
 }
 
 export async function deleteSession(account: string): Promise<void> {

--- a/utils/credential-format.ts
+++ b/utils/credential-format.ts
@@ -324,9 +324,7 @@ async function getGroupId(groupUri: string) {
   return result.results.bindings[0].groupId.value;
 }
 
-export async function selectAccountBySession(
-  sessionUri: string,
-): Promise<{
+export async function selectAccountBySession(sessionUri: string): Promise<{
   account: string;
   sessionId: string;
   accountId: string;


### PR DESCRIPTION
When logging in through verifiable credentials, we need to know which account is associated with the verifiable credential, so that account can be logged in. This commit adds a route that provides that information.

# See also

- https://github.com/lblod/frontend-decide/pull/5
- https://github.com/lblod/app-decide/pull/17