### PR TITLE
better support for wallets that identify using did

### DIFF
--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -177,21 +177,27 @@ export async function getIssuerRouter(issuer: VCIssuer) {
       return;
     }
 
-    const { did, jwk } = await issuer
+    const { did, jwk, walletSupportsDid } = await issuer
       .validateProofAndGetHolderDid(jwt, expectedNonce)
       .catch((e) => {
         logger.error(`Error validating proof: ${e}`);
         res.status(400).send({ error: e.message });
-        return { did: null, jwk: null };
+        return { did: null, jwk: null, walletSupportsDid: false };
       });
     if (!did) {
       return; // we already sent a response in the catch block
     }
 
     logger.debug(`holder did: ${did}`);
-    logger.debug(`holder jwk: ${jwk}`);
+    logger.debug(`holder jwk: ${JSON.stringify(jwk)}`);
 
-    const signedVC = await issuer.issueCredential(did, jwk, sessionInfo, token);
+    const signedVC = await issuer.issueCredential(
+      did,
+      jwk,
+      sessionInfo,
+      token,
+      walletSupportsDid,
+    );
 
     const response = {
       c_nonce: await issuer.generateNonce(walletSession), // for old specs

--- a/services/issuer.ts
+++ b/services/issuer.ts
@@ -91,8 +91,14 @@ export class VCIssuer {
     jwk,
     sessionInfo: SessionInfo,
     authToken: string,
+    walletSupportsDid: boolean,
   ) {
-    const res = this.sdJwtService.buildCredential(holderDid, jwk, sessionInfo);
+    const res = this.sdJwtService.buildCredential(
+      holderDid,
+      jwk,
+      sessionInfo,
+      walletSupportsDid,
+    );
     await this.updateIssuanceStatusForAuthToken(authToken, 'issued');
     return res;
   }
@@ -319,9 +325,11 @@ export class VCIssuer {
       throw new Error('invalid_nonce');
     }
     let did = decodedJwtHeader.kid;
+    let walletSupportsDid = true;
     // fall back to jwk and create a did:key from it
     if (!did || !did.startsWith('did:')) {
       did = this.buildDidKeyFromJwk(decodedJwtHeader.jwk);
+      walletSupportsDid = false;
     }
     if (!did || !did.startsWith('did:')) {
       throw new Error('invalid_proof');
@@ -344,7 +352,7 @@ export class VCIssuer {
       throw new Error('invalid_proof');
     });
 
-    return { did, jwk };
+    return { did, jwk, walletSupportsDid };
   }
 
   async checkNonce(expectedNonce, decodedNonce) {

--- a/services/sd-jwt-vc.ts
+++ b/services/sd-jwt-vc.ts
@@ -10,6 +10,7 @@ import * as Crypto from 'node:crypto';
 import {
   getPrivateKeyAsCryptoKey,
   getPublicKeyAsCryptoKey,
+  resolveDid,
 } from '../utils/crypto';
 import env from '../utils/environment';
 import {
@@ -18,6 +19,19 @@ import {
   SessionInfo,
 } from '../utils/credential-format';
 import { logger } from '../utils/logger';
+
+const getHolderJwkFromDid = async (did) => {
+  const resolvedDid = await resolveDid(did);
+  if (!resolvedDid) {
+    throw new Error(`Could not resolve DID: ${did}`);
+  }
+  const publicKey =
+    resolvedDid.didDocument?.verificationMethod?.[0]?.publicKeyJwk;
+  if (!publicKey) {
+    throw new Error(`No public key found for DID: ${did}`);
+  }
+  return publicKey;
+};
 
 const createSignerVerifier = () => {
   const privateKey = getPrivateKeyAsCryptoKey();
@@ -36,7 +50,12 @@ const createSignerVerifier = () => {
     );
   };
   const kbVerifier = async (data: string, sig: string, payload: JwtPayload) => {
-    const holderJwk = payload.cnf?.jwk;
+    let holderJwk = payload.cnf?.jwk;
+    if (!holderJwk) {
+      holderJwk = await getHolderJwkFromDid(
+        (payload.cnf as unknown as { kid: string })?.kid,
+      );
+    }
     const holderPublicKey = await Crypto.subtle.importKey(
       'jwk',
       holderJwk as JsonWebKey,
@@ -86,7 +105,12 @@ export class SDJwtVCService {
     this.ready = true;
   }
 
-  async buildCredential(ownerDid: string, jwk, sessionInfo: SessionInfo) {
+  async buildCredential(
+    ownerDid: string,
+    jwk,
+    sessionInfo: SessionInfo,
+    walletSupportsDid: boolean,
+  ) {
     // Issuer Define the claims object with the user's information
     const claims = {
       did: ownerDid,
@@ -98,6 +122,15 @@ export class SDJwtVCService {
       _sd: getDisclosureFrame(),
     };
 
+    let cnf: { kid?: string; jwk?: string } = {
+      kid: ownerDid,
+    };
+    if (!walletSupportsDid) {
+      cnf = {
+        jwk: jwk,
+      };
+    }
+
     // Issue a signed JWT credential with the specified claims and disclosures
     // Return a Encoded SD JWT. Issuer send the credential to the holder
     const credential = await this.sdjwt.issue(
@@ -105,9 +138,7 @@ export class SDJwtVCService {
         iss: env.ISSUER_DID,
         iat: Math.floor(Date.now() / 1000),
         vct: env.ISSUER_URL,
-        cnf: {
-          jwk,
-        },
+        cnf,
         ...claims,
       },
       disclosureFrame,


### PR DESCRIPTION
Paradym updated and now require that the credential they receive is actually bound to the did they presented, just binding to the jwk contained in the did is no longer enough.