### PR TITLE
Store events during issuance and verification flows in triplestore

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,13 @@
+steps:
+  build-feature:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ${CI_REPO}
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: push
+    branch: [feature/*]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You may not have an existing did file or public/private keys. In that case, fill
 - **VERIFIER_USE_X509**: whether or not the verifier should use an x509_hash clientId. Default = false. This is required to make the verifier work with the EUDI wallet, which doesn't support DIDs at the time of this writing.
 - **VERIFIER_X509_CERTS**: required if VERIFIER_USE_X509 is true, points to the location of the x509 certificates as a folder that should contain fullchain.pem, key.pem and cert.pem.
 - **WORKING_GRAPH**: the uri of the temporary graph to put data related to the issuance and verification of verifiable credentials. This data is always short-lived, you should be able to delete this graph at any time. Default 'http://mu.semte.ch/graphs/verifiable-credentials/temp'
+- **LOG_GRAPH**: the uri of the graph to put triples describing start, finish and possibly fail events happening during the issuing and verification flows. Default 'http://mu.semte.ch/graphs/verifiable-credentials/logs'
 
 Note: ES256 is untested, all wallets tested so far.
 

--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -10,6 +10,7 @@ import {
 } from '../utils/credential-format';
 import { VCIssuer } from '../services/issuer';
 import { logger } from '../utils/logger';
+import { logIssuanceStarted, logIssuanceSucceeded } from '../utils/flow-logger';
 
 export async function getIssuerRouter(issuer: VCIssuer) {
   const router = Router();
@@ -162,6 +163,9 @@ export async function getIssuerRouter(issuer: VCIssuer) {
       res.status(401).send({ error: 'invalid_token' });
       return;
     }
+
+    await logIssuanceStarted(sessionInfo.sessionUri!);
+
     // we don't actually have multiple credential types yet, so even if the wallet sends this, we can ignore it
     // if (credential_configuration_id !== env.CREDENTIAL_TYPE) {
     //   res.status(400).send({ error: 'invalid_credential_configuration_id' });
@@ -211,6 +215,8 @@ export async function getIssuerRouter(issuer: VCIssuer) {
     } else {
       response['credentials'] = [{ credential: signedVC }];
     }
+
+    await logIssuanceSucceeded(sessionInfo.sessionUri!, sessionInfo);
 
     res.send(response);
   });

--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -170,74 +170,84 @@ export async function getIssuerRouter(issuer: VCIssuer) {
 
     await logIssuanceStarted(sessionInfo.sessionUri!);
 
-    try {
-      // we don't actually have multiple credential types yet, so even if the wallet sends this, we can ignore it
-      // if (credential_configuration_id !== env.CREDENTIAL_TYPE) {
-      //   res.status(400).send({ error: 'invalid_credential_configuration_id' });
-      //   return;
-      // }
-      if (!jwt) {
-        await logIssuanceFailed(sessionInfo.sessionUri!, 'missing_proof');
-        res.status(400).send({ error: 'missing_proof' });
-        return;
-      }
-      const payload = jwt.split('.')[1];
-      if (!payload) {
-        await logIssuanceFailed(sessionInfo.sessionUri!, 'invalid_proof');
-        res.status(400).send({ error: 'invalid_proof' });
-        return;
-      }
-
-      const { did, jwk, walletSupportsDid } = await issuer
-        .validateProofAndGetHolderDid(jwt, expectedNonce)
-        .catch(async (e) => {
-          const message = e instanceof Error ? e.message : String(e);
-          logger.error(`Error validating proof: ${message}`);
-          await logIssuanceFailed(sessionInfo.sessionUri!, message);
-          res.status(400).send({ error: message });
-          return { did: null, jwk: null, walletSupportsDid: false };
-        });
-
-      if (!did) {
-        return; // we already sent a response in the catch block
-      }
-
-      logger.debug(`holder did: ${did}`);
-      logger.debug(`holder jwk: ${JSON.stringify(jwk)}`);
-
-      const signedVC = await issuer.issueCredential(
-        did,
-        jwk,
-        sessionInfo,
-        token,
-        walletSupportsDid,
-      );
-
-      const response = {
-        c_nonce: await issuer.generateNonce(walletSession), // for old specs
-        c_nonce_expires_in: 300, // yeah... it really doesn't, for old specs
-        format: 'vc+sd-jwt', // for old specs
-      };
-
-      // old specs want a single credential, newer specs want an array of credentials.
-      if (env.SINGLE_CREDENTIAL_RESPONSE) {
-        response['credential'] = signedVC;
-      } else {
-        response['credentials'] = [{ credential: signedVC }];
-      }
-
-      await logIssuanceSucceeded(sessionInfo.sessionUri!, sessionInfo);
-
-      res.send(response);
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      logger.error(`Error during credential issuance: ${message}`);
-      await logIssuanceFailed(sessionInfo.sessionUri!, message);
-
-      if (!res.headersSent) {
-        res.status(400).send({ error: message });
-      }
+    // we don't actually have multiple credential types yet, so even if the wallet sends this, we can ignore it
+    // if (credential_configuration_id !== env.CREDENTIAL_TYPE) {
+    //   res.status(400).send({ error: 'invalid_credential_configuration_id' });
+    //   return;
+    // }
+    if (!jwt) {
+      await logIssuanceFailed(sessionInfo.sessionUri!, 'missing_proof');
+      res.status(400).send({ error: 'missing_proof' });
+      return;
     }
+    const payload = jwt.split('.')[1];
+    if (!payload) {
+      await logIssuanceFailed(sessionInfo.sessionUri!, 'invalid_proof');
+      res.status(400).send({ error: 'invalid_proof' });
+      return;
+    }
+
+    const { did, jwk, walletSupportsDid } = await issuer
+      .validateProofAndGetHolderDid(jwt, expectedNonce)
+      .catch(async (e) => {
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error(`Error validating proof: ${message}`);
+        await logIssuanceFailed(sessionInfo.sessionUri!, message);
+        res.status(400).send({ error: message });
+        return { did: null, jwk: null, walletSupportsDid: false };
+      });
+
+    if (!did) {
+      return; // we already sent a response in the catch block
+    }
+
+    logger.debug(`holder did: ${did}`);
+    logger.debug(`holder jwk: ${JSON.stringify(jwk)}`);
+
+    const signedVC = await issuer
+      .issueCredential(did, jwk, sessionInfo, token, walletSupportsDid)
+      .catch(async (e) => {
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error(`Error issuing credential: ${message}`);
+        await logIssuanceFailed(sessionInfo.sessionUri!, message);
+        res.status(400).send({ error: message });
+        return null;
+      });
+
+    if (!signedVC) {
+      return;
+    }
+
+    const cNonce = await issuer
+      .generateNonce(walletSession)
+      .catch(async (e) => {
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error(`Error generating issuance nonce: ${message}`);
+        await logIssuanceFailed(sessionInfo.sessionUri!, message);
+        res.status(500).send({ error: message });
+        return null;
+      });
+
+    if (!cNonce) {
+      return;
+    }
+
+    const response = {
+      c_nonce: cNonce, // for old specs
+      c_nonce_expires_in: 300, // yeah... it really doesn't, for old specs
+      format: 'vc+sd-jwt', // for old specs
+    };
+
+    // old specs want a single credential, newer specs want an array of credentials.
+    if (env.SINGLE_CREDENTIAL_RESPONSE) {
+      response['credential'] = signedVC;
+    } else {
+      response['credentials'] = [{ credential: signedVC }];
+    }
+
+    await logIssuanceSucceeded(sessionInfo.sessionUri!, sessionInfo);
+
+    res.send(response);
   });
 
   router.get('/issuance-status', async (req, res) => {

--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -11,10 +11,10 @@ import {
 import { VCIssuer } from '../services/issuer';
 import { logger } from '../utils/logger';
 import {
-  logIssuanceFailed,
-  logIssuanceStarted,
-  logIssuanceSucceeded,
-} from '../utils/flow-logger';
+  storeCredentialIssuanceFailedEvent,
+  storeCredentialIssuanceStartedEvent,
+  storeCredentialIssuanceSucceededEvent,
+} from '../utils/flow-event-store';
 
 export async function getIssuerRouter(issuer: VCIssuer) {
   const router = Router();
@@ -168,7 +168,7 @@ export async function getIssuerRouter(issuer: VCIssuer) {
       return;
     }
 
-    await logIssuanceStarted(sessionInfo.sessionUri!);
+    await storeCredentialIssuanceStartedEvent(sessionInfo.sessionUri!);
 
     // we don't actually have multiple credential types yet, so even if the wallet sends this, we can ignore it
     // if (credential_configuration_id !== env.CREDENTIAL_TYPE) {
@@ -178,7 +178,10 @@ export async function getIssuerRouter(issuer: VCIssuer) {
     if (!jwt) {
       const message = 'missing_proof';
       logger.error(message);
-      await logIssuanceFailed(sessionInfo.sessionUri!, message);
+      await storeCredentialIssuanceFailedEvent(
+        sessionInfo.sessionUri!,
+        message,
+      );
       res.status(400).send({ error: message });
       return;
     }
@@ -186,7 +189,10 @@ export async function getIssuerRouter(issuer: VCIssuer) {
     if (!payload) {
       const message = 'invalid_proof';
       logger.error(message);
-      await logIssuanceFailed(sessionInfo.sessionUri!, message);
+      await storeCredentialIssuanceFailedEvent(
+        sessionInfo.sessionUri!,
+        message,
+      );
       res.status(400).send({ error: message });
       return;
     }
@@ -197,7 +203,10 @@ export async function getIssuerRouter(issuer: VCIssuer) {
         const errorMessage = e instanceof Error ? e.message : String(e);
         const message = `Error validating proof: ${errorMessage}`;
         logger.error(message);
-        await logIssuanceFailed(sessionInfo.sessionUri!, message);
+        await storeCredentialIssuanceFailedEvent(
+          sessionInfo.sessionUri!,
+          message,
+        );
         res.status(400).send({ error: errorMessage });
         return { did: null, jwk: null, walletSupportsDid: false };
       });
@@ -215,7 +224,10 @@ export async function getIssuerRouter(issuer: VCIssuer) {
         const errorMessage = e instanceof Error ? e.message : String(e);
         const message = `Error issuing credential: ${errorMessage}`;
         logger.error(message);
-        await logIssuanceFailed(sessionInfo.sessionUri!, message);
+        await storeCredentialIssuanceFailedEvent(
+          sessionInfo.sessionUri!,
+          message,
+        );
         res.status(400).send({ error: errorMessage });
         return null;
       });
@@ -230,7 +242,10 @@ export async function getIssuerRouter(issuer: VCIssuer) {
         const errorMessage = e instanceof Error ? e.message : String(e);
         const message = `Error generating issuance nonce: ${errorMessage}`;
         logger.error(message);
-        await logIssuanceFailed(sessionInfo.sessionUri!, message);
+        await storeCredentialIssuanceFailedEvent(
+          sessionInfo.sessionUri!,
+          message,
+        );
         res.status(500).send({ error: errorMessage });
         return null;
       });
@@ -252,7 +267,10 @@ export async function getIssuerRouter(issuer: VCIssuer) {
       response['credentials'] = [{ credential: signedVC }];
     }
 
-    await logIssuanceSucceeded(sessionInfo.sessionUri!, sessionInfo);
+    await storeCredentialIssuanceSucceededEvent(
+      sessionInfo.sessionUri!,
+      sessionInfo,
+    );
 
     res.send(response);
   });

--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -176,24 +176,29 @@ export async function getIssuerRouter(issuer: VCIssuer) {
     //   return;
     // }
     if (!jwt) {
-      await logIssuanceFailed(sessionInfo.sessionUri!, 'missing_proof');
-      res.status(400).send({ error: 'missing_proof' });
+      const message = 'missing_proof';
+      logger.error(message);
+      await logIssuanceFailed(sessionInfo.sessionUri!, message);
+      res.status(400).send({ error: message });
       return;
     }
     const payload = jwt.split('.')[1];
     if (!payload) {
-      await logIssuanceFailed(sessionInfo.sessionUri!, 'invalid_proof');
-      res.status(400).send({ error: 'invalid_proof' });
+      const message = 'invalid_proof';
+      logger.error(message);
+      await logIssuanceFailed(sessionInfo.sessionUri!, message);
+      res.status(400).send({ error: message });
       return;
     }
 
     const { did, jwk, walletSupportsDid } = await issuer
       .validateProofAndGetHolderDid(jwt, expectedNonce)
       .catch(async (e) => {
-        const message = e instanceof Error ? e.message : String(e);
-        logger.error(`Error validating proof: ${message}`);
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        const message = `Error validating proof: ${errorMessage}`;
+        logger.error(message);
         await logIssuanceFailed(sessionInfo.sessionUri!, message);
-        res.status(400).send({ error: message });
+        res.status(400).send({ error: errorMessage });
         return { did: null, jwk: null, walletSupportsDid: false };
       });
 
@@ -207,10 +212,11 @@ export async function getIssuerRouter(issuer: VCIssuer) {
     const signedVC = await issuer
       .issueCredential(did, jwk, sessionInfo, token, walletSupportsDid)
       .catch(async (e) => {
-        const message = e instanceof Error ? e.message : String(e);
-        logger.error(`Error issuing credential: ${message}`);
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        const message = `Error issuing credential: ${errorMessage}`;
+        logger.error(message);
         await logIssuanceFailed(sessionInfo.sessionUri!, message);
-        res.status(400).send({ error: message });
+        res.status(400).send({ error: errorMessage });
         return null;
       });
 
@@ -221,10 +227,11 @@ export async function getIssuerRouter(issuer: VCIssuer) {
     const cNonce = await issuer
       .generateNonce(walletSession)
       .catch(async (e) => {
-        const message = e instanceof Error ? e.message : String(e);
-        logger.error(`Error generating issuance nonce: ${message}`);
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        const message = `Error generating issuance nonce: ${errorMessage}`;
+        logger.error(message);
         await logIssuanceFailed(sessionInfo.sessionUri!, message);
-        res.status(500).send({ error: message });
+        res.status(500).send({ error: errorMessage });
         return null;
       });
 

--- a/routers/issuer.ts
+++ b/routers/issuer.ts
@@ -10,7 +10,11 @@ import {
 } from '../utils/credential-format';
 import { VCIssuer } from '../services/issuer';
 import { logger } from '../utils/logger';
-import { logIssuanceStarted, logIssuanceSucceeded } from '../utils/flow-logger';
+import {
+  logIssuanceFailed,
+  logIssuanceStarted,
+  logIssuanceSucceeded,
+} from '../utils/flow-logger';
 
 export async function getIssuerRouter(issuer: VCIssuer) {
   const router = Router();
@@ -166,59 +170,74 @@ export async function getIssuerRouter(issuer: VCIssuer) {
 
     await logIssuanceStarted(sessionInfo.sessionUri!);
 
-    // we don't actually have multiple credential types yet, so even if the wallet sends this, we can ignore it
-    // if (credential_configuration_id !== env.CREDENTIAL_TYPE) {
-    //   res.status(400).send({ error: 'invalid_credential_configuration_id' });
-    //   return;
-    // }
-    if (!jwt) {
-      res.status(400).send({ error: 'missing_proof' });
-      return;
+    try {
+      // we don't actually have multiple credential types yet, so even if the wallet sends this, we can ignore it
+      // if (credential_configuration_id !== env.CREDENTIAL_TYPE) {
+      //   res.status(400).send({ error: 'invalid_credential_configuration_id' });
+      //   return;
+      // }
+      if (!jwt) {
+        await logIssuanceFailed(sessionInfo.sessionUri!, 'missing_proof');
+        res.status(400).send({ error: 'missing_proof' });
+        return;
+      }
+      const payload = jwt.split('.')[1];
+      if (!payload) {
+        await logIssuanceFailed(sessionInfo.sessionUri!, 'invalid_proof');
+        res.status(400).send({ error: 'invalid_proof' });
+        return;
+      }
+
+      const { did, jwk, walletSupportsDid } = await issuer
+        .validateProofAndGetHolderDid(jwt, expectedNonce)
+        .catch(async (e) => {
+          const message = e instanceof Error ? e.message : String(e);
+          logger.error(`Error validating proof: ${message}`);
+          await logIssuanceFailed(sessionInfo.sessionUri!, message);
+          res.status(400).send({ error: message });
+          return { did: null, jwk: null, walletSupportsDid: false };
+        });
+
+      if (!did) {
+        return; // we already sent a response in the catch block
+      }
+
+      logger.debug(`holder did: ${did}`);
+      logger.debug(`holder jwk: ${JSON.stringify(jwk)}`);
+
+      const signedVC = await issuer.issueCredential(
+        did,
+        jwk,
+        sessionInfo,
+        token,
+        walletSupportsDid,
+      );
+
+      const response = {
+        c_nonce: await issuer.generateNonce(walletSession), // for old specs
+        c_nonce_expires_in: 300, // yeah... it really doesn't, for old specs
+        format: 'vc+sd-jwt', // for old specs
+      };
+
+      // old specs want a single credential, newer specs want an array of credentials.
+      if (env.SINGLE_CREDENTIAL_RESPONSE) {
+        response['credential'] = signedVC;
+      } else {
+        response['credentials'] = [{ credential: signedVC }];
+      }
+
+      await logIssuanceSucceeded(sessionInfo.sessionUri!, sessionInfo);
+
+      res.send(response);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      logger.error(`Error during credential issuance: ${message}`);
+      await logIssuanceFailed(sessionInfo.sessionUri!, message);
+
+      if (!res.headersSent) {
+        res.status(400).send({ error: message });
+      }
     }
-    const payload = jwt.split('.')[1];
-    if (!payload) {
-      res.status(400).send({ error: 'invalid_proof' });
-      return;
-    }
-
-    const { did, jwk, walletSupportsDid } = await issuer
-      .validateProofAndGetHolderDid(jwt, expectedNonce)
-      .catch((e) => {
-        logger.error(`Error validating proof: ${e}`);
-        res.status(400).send({ error: e.message });
-        return { did: null, jwk: null, walletSupportsDid: false };
-      });
-    if (!did) {
-      return; // we already sent a response in the catch block
-    }
-
-    logger.debug(`holder did: ${did}`);
-    logger.debug(`holder jwk: ${JSON.stringify(jwk)}`);
-
-    const signedVC = await issuer.issueCredential(
-      did,
-      jwk,
-      sessionInfo,
-      token,
-      walletSupportsDid,
-    );
-
-    const response = {
-      c_nonce: await issuer.generateNonce(walletSession), // for old specs
-      c_nonce_expires_in: 300, // yeah... it really doesn't, for old specs
-      format: 'vc+sd-jwt', // for old specs
-    };
-
-    // old specs want a single credential, newer specs want an array of credentials.
-    if (env.SINGLE_CREDENTIAL_RESPONSE) {
-      response['credential'] = signedVC;
-    } else {
-      response['credentials'] = [{ credential: signedVC }];
-    }
-
-    await logIssuanceSucceeded(sessionInfo.sessionUri!, sessionInfo);
-
-    res.send(response);
   });
 
   router.get('/issuance-status', async (req, res) => {

--- a/services/verifier.ts
+++ b/services/verifier.ts
@@ -17,6 +17,10 @@ import {
   SessionInfo,
   updateSessionWithCredentialInfo,
 } from '../utils/credential-format';
+import {
+  logVerificationStarted,
+  logVerificationSucceeded,
+} from '../utils/flow-logger';
 import { logger } from '../utils/logger';
 
 export class VCVerifier {
@@ -286,10 +290,14 @@ export class VCVerifier {
     if (!response) {
       throw new Error('No response field in presentation response');
     }
+
+    await logVerificationStarted(originalSession);
+
     const { nonce, privateKey } = await this.fetchAuthorizationRequestKey(
       originalSession,
       responseCode,
     );
+
     const { payload, protectedHeader } = await jose.jwtDecrypt(
       response,
       privateKey,
@@ -346,6 +354,11 @@ export class VCVerifier {
         );
         throw new Error('Could not verify the credential');
       });
+
+    await logVerificationSucceeded(
+      originalSession,
+      verified.payload as SessionInfo,
+    );
 
     return verified;
   }

--- a/services/verifier.ts
+++ b/services/verifier.ts
@@ -18,6 +18,7 @@ import {
   updateSessionWithCredentialInfo,
 } from '../utils/credential-format';
 import {
+  logVerificationFailed,
   logVerificationStarted,
   logVerificationSucceeded,
 } from '../utils/flow-logger';
@@ -298,17 +299,30 @@ export class VCVerifier {
       responseCode,
     );
 
-    const { payload, protectedHeader } = await jose.jwtDecrypt(
-      response,
-      privateKey,
-      {
+    const { payload, protectedHeader } = await jose
+      .jwtDecrypt(response, privateKey, {
         contentEncryptionAlgorithms: ['A128GCM'],
         keyManagementAlgorithms: ['ECDH-ES'],
         // we could verify the audience here if we wanted to be sure it's meant for us
-      },
-    );
+      })
+      .catch(async (e) => {
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error(`Error decrypting presentation response: ${message}`);
+        await this.updateAuthorizationRequestStatus(
+          originalSession,
+          'rejected',
+        );
+        await logVerificationFailed(originalSession, message);
+        throw e;
+      });
+
     const vp_token = payload.vp_token as { roles_credential?: string };
     if (!vp_token?.roles_credential) {
+      await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
+      await logVerificationFailed(
+        originalSession,
+        'No roles_credential in vp_token',
+      );
       throw new Error('No roles_credential in vp_token');
     }
     const credential = vp_token.roles_credential;
@@ -324,36 +338,41 @@ export class VCVerifier {
 
     const verified = await this.sdJwtService
       .validateAndDecodeCredential(safeCredential, nonce)
-      .then(async (res) => {
-        const payload = res.payload;
-
-        if (!(await this.isTrustedIssuer(res))) {
-          throw new Error('Credential issuer is not trusted');
-        }
-        logger.debug(
-          `Credential verified successfully: ${JSON.stringify(res, null, 2)}`,
-        );
-
-        await updateSessionWithCredentialInfo(
-          originalSession,
-          payload as SessionInfo,
-        );
-
-        await this.updateAuthorizationRequestStatus(
-          originalSession,
-          'accepted',
-        );
-
-        return res;
-      })
       .catch(async (e) => {
-        logger.error(`Error verifying credential: ${e}`);
+        const message = e instanceof Error ? e.message : String(e);
+        logger.error(`Error verifying credential: ${message}`);
         await this.updateAuthorizationRequestStatus(
           originalSession,
           'rejected',
         );
+        await logVerificationFailed(originalSession, message);
         throw new Error('Could not verify the credential');
       });
+
+    if (!(await this.isTrustedIssuer(verified))) {
+      await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
+      await logVerificationFailed(
+        originalSession,
+        'Credential issuer is not trusted',
+      );
+      throw new Error('Credential issuer is not trusted');
+    }
+    logger.debug(
+      `Credential verified successfully: ${JSON.stringify(verified, null, 2)}`,
+    );
+
+    await updateSessionWithCredentialInfo(
+      originalSession,
+      verified.payload as SessionInfo,
+    ).catch(async (e) => {
+      const message = e instanceof Error ? e.message : String(e);
+      logger.error(`Error updating session with credential info: ${message}`);
+      await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
+      await logVerificationFailed(originalSession, message);
+      throw e;
+    });
+
+    await this.updateAuthorizationRequestStatus(originalSession, 'accepted');
 
     await logVerificationSucceeded(
       originalSession,

--- a/services/verifier.ts
+++ b/services/verifier.ts
@@ -18,10 +18,10 @@ import {
   updateSessionWithCredentialInfo,
 } from '../utils/credential-format';
 import {
-  logVerificationFailed,
-  logVerificationStarted,
-  logVerificationSucceeded,
-} from '../utils/flow-logger';
+  storeCredentialVerificationFailedEvent,
+  storeCredentialVerificationStartedEvent,
+  storeCredentialVerificationSucceededEvent,
+} from '../utils/flow-event-store';
 import { logger } from '../utils/logger';
 
 export class VCVerifier {
@@ -292,7 +292,7 @@ export class VCVerifier {
       throw new Error('No response field in presentation response');
     }
 
-    await logVerificationStarted(originalSession);
+    await storeCredentialVerificationStartedEvent(originalSession);
 
     const { nonce, privateKey } = await this.fetchAuthorizationRequestKey(
       originalSession,
@@ -313,7 +313,7 @@ export class VCVerifier {
           originalSession,
           'rejected',
         );
-        await logVerificationFailed(originalSession, message);
+        await storeCredentialVerificationFailedEvent(originalSession, message);
         throw e;
       });
 
@@ -322,7 +322,7 @@ export class VCVerifier {
       const message = 'No roles_credential in vp_token';
       logger.error(message);
       await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
-      await logVerificationFailed(originalSession, message);
+      await storeCredentialVerificationFailedEvent(originalSession, message);
       throw new Error(message);
     }
     const credential = vp_token.roles_credential;
@@ -347,7 +347,7 @@ export class VCVerifier {
           originalSession,
           'rejected',
         );
-        await logVerificationFailed(originalSession, message);
+        await storeCredentialVerificationFailedEvent(originalSession, message);
         throw new Error(responseMessage);
       });
 
@@ -355,7 +355,7 @@ export class VCVerifier {
       const message = 'Credential issuer is not trusted';
       logger.error(message);
       await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
-      await logVerificationFailed(originalSession, message);
+      await storeCredentialVerificationFailedEvent(originalSession, message);
       throw new Error(message);
     }
     logger.debug(
@@ -370,13 +370,13 @@ export class VCVerifier {
       const message = `Error updating session with credential info: ${errorMessage}`;
       logger.error(message);
       await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
-      await logVerificationFailed(originalSession, message);
+      await storeCredentialVerificationFailedEvent(originalSession, message);
       throw e;
     });
 
     await this.updateAuthorizationRequestStatus(originalSession, 'accepted');
 
-    await logVerificationSucceeded(
+    await storeCredentialVerificationSucceededEvent(
       originalSession,
       verified.payload as SessionInfo,
     );

--- a/services/verifier.ts
+++ b/services/verifier.ts
@@ -306,8 +306,9 @@ export class VCVerifier {
         // we could verify the audience here if we wanted to be sure it's meant for us
       })
       .catch(async (e) => {
-        const message = e instanceof Error ? e.message : String(e);
-        logger.error(`Error decrypting presentation response: ${message}`);
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        const message = `Error decrypting presentation response: ${errorMessage}`;
+        logger.error(message);
         await this.updateAuthorizationRequestStatus(
           originalSession,
           'rejected',
@@ -318,12 +319,11 @@ export class VCVerifier {
 
     const vp_token = payload.vp_token as { roles_credential?: string };
     if (!vp_token?.roles_credential) {
+      const message = 'No roles_credential in vp_token';
+      logger.error(message);
       await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
-      await logVerificationFailed(
-        originalSession,
-        'No roles_credential in vp_token',
-      );
-      throw new Error('No roles_credential in vp_token');
+      await logVerificationFailed(originalSession, message);
+      throw new Error(message);
     }
     const credential = vp_token.roles_credential;
 
@@ -339,23 +339,24 @@ export class VCVerifier {
     const verified = await this.sdJwtService
       .validateAndDecodeCredential(safeCredential, nonce)
       .catch(async (e) => {
-        const message = e instanceof Error ? e.message : String(e);
-        logger.error(`Error verifying credential: ${message}`);
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        const message = `Error verifying credential: ${errorMessage}`;
+        const responseMessage = 'Could not verify the credential';
+        logger.error(message);
         await this.updateAuthorizationRequestStatus(
           originalSession,
           'rejected',
         );
         await logVerificationFailed(originalSession, message);
-        throw new Error('Could not verify the credential');
+        throw new Error(responseMessage);
       });
 
     if (!(await this.isTrustedIssuer(verified))) {
+      const message = 'Credential issuer is not trusted';
+      logger.error(message);
       await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
-      await logVerificationFailed(
-        originalSession,
-        'Credential issuer is not trusted',
-      );
-      throw new Error('Credential issuer is not trusted');
+      await logVerificationFailed(originalSession, message);
+      throw new Error(message);
     }
     logger.debug(
       `Credential verified successfully: ${JSON.stringify(verified, null, 2)}`,
@@ -365,8 +366,9 @@ export class VCVerifier {
       originalSession,
       verified.payload as SessionInfo,
     ).catch(async (e) => {
-      const message = e instanceof Error ? e.message : String(e);
-      logger.error(`Error updating session with credential info: ${message}`);
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      const message = `Error updating session with credential info: ${errorMessage}`;
+      logger.error(message);
       await this.updateAuthorizationRequestStatus(originalSession, 'rejected');
       await logVerificationFailed(originalSession, message);
       throw e;

--- a/utils/credential-format.ts
+++ b/utils/credential-format.ts
@@ -147,6 +147,7 @@ export type SessionInfo = {
   lastName?: string;
   group: string;
   roles: string;
+  sessionUri?: string;
 };
 
 export const getSessionInfoForCredentialOfferToken = async (token: string) => {
@@ -156,7 +157,7 @@ export const getSessionInfoForCredentialOfferToken = async (token: string) => {
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
-      SELECT ?accountUri ?accountId ?userUri ?userId ?firstName ?lastName ?group ?role {
+      SELECT ?session ?accountUri ?accountId ?userUri ?userId ?firstName ?lastName ?group ?role {
         GRAPH ${sparqlEscapeUri(env.WORKING_GRAPH)} {
           ?token a ext:CredentialOfferToken .
           ?token ext:issuerUrl ${sparqlEscapeString(env.ISSUER_URL)} .
@@ -185,6 +186,7 @@ export const getSessionInfoForCredentialOfferToken = async (token: string) => {
   const certificateInfo = {};
 
   const firstResult = result.results.bindings[0];
+  certificateInfo['sessionUri'] = firstResult.session.value;
   certificateInfo['accountUri'] = firstResult.accountUri.value;
   if (firstResult.accountId) {
     certificateInfo['accountId'] = firstResult.accountId.value;

--- a/utils/environment.ts
+++ b/utils/environment.ts
@@ -69,6 +69,9 @@ const environment = {
   WORKING_GRAPH:
     process.env.WORKING_GRAPH ||
     'http://mu.semte.ch/graphs/verifiable-credentials/temp',
+  LOG_GRAPH:
+    process.env.LOG_GRAPH ||
+    'http://mu.semte.ch/graphs/verifiable-credentials/logs',
 };
 
 if (environment.VERIFIER_USE_X509) {

--- a/utils/flow-event-store.ts
+++ b/utils/flow-event-store.ts
@@ -8,24 +8,25 @@ import {
 import type { SessionInfo } from './credential-format';
 import env from './environment';
 
-const EVENT_URI_BASE = 'http://data.lblod.info/flow-event/';
+const FLOW_EVENT_URI_BASE = 'http://data.lblod.info/flow-event/';
 
-const ISSUANCE_FLOW_EVENT = 'ext:VCIssuanceFlowEvent' as const;
-const VERIFICATION_FLOW_EVENT = 'ext:VCVerificationFlowEvent' as const;
+const CREDENTIAL_ISSUANCE_EVENT = 'ext:CredentialIssuanceEvent' as const;
+const CREDENTIAL_VERIFICATION_EVENT =
+  'ext:CredentialVerificationEvent' as const;
 
-type FlowEventType =
-  | typeof ISSUANCE_FLOW_EVENT
-  | typeof VERIFICATION_FLOW_EVENT;
+type CredentialFlowEventType =
+  | typeof CREDENTIAL_ISSUANCE_EVENT
+  | typeof CREDENTIAL_VERIFICATION_EVENT;
 
-async function insertFlowEvent(
-  rdfType: FlowEventType,
+async function storeCredentialFlowEvent(
+  rdfType: CredentialFlowEventType,
   eventType: string,
   sessionUri: string,
   sessionInfo?: SessionInfo,
   errorMessage?: string,
 ): Promise<void> {
   const id = uuid();
-  const uri = `${EVENT_URI_BASE}${id}`;
+  const uri = `${FLOW_EVENT_URI_BASE}${id}`;
 
   const extraTriples: string[] = [];
   if (sessionInfo) {
@@ -58,58 +59,70 @@ async function insertFlowEvent(
   `);
 }
 
-export function logIssuanceStarted(sessionUri: string): Promise<void> {
-  return insertFlowEvent(ISSUANCE_FLOW_EVENT, 'started', sessionUri);
+export function storeCredentialIssuanceStartedEvent(
+  sessionUri: string,
+): Promise<void> {
+  return storeCredentialFlowEvent(
+    CREDENTIAL_ISSUANCE_EVENT,
+    'issuance-started',
+    sessionUri,
+  );
 }
 
-export function logIssuanceSucceeded(
+export function storeCredentialIssuanceSucceededEvent(
   sessionUri: string,
   sessionInfo: SessionInfo,
 ): Promise<void> {
-  return insertFlowEvent(
-    ISSUANCE_FLOW_EVENT,
-    'credential-issued',
+  return storeCredentialFlowEvent(
+    CREDENTIAL_ISSUANCE_EVENT,
+    'issuance-succeeded',
     sessionUri,
     sessionInfo,
   );
 }
 
-export function logIssuanceFailed(
+export function storeCredentialIssuanceFailedEvent(
   sessionUri: string,
   errorMessage: string,
 ): Promise<void> {
-  return insertFlowEvent(
-    ISSUANCE_FLOW_EVENT,
-    'failed',
+  return storeCredentialFlowEvent(
+    CREDENTIAL_ISSUANCE_EVENT,
+    'issuance-failed',
     sessionUri,
     undefined,
     errorMessage,
   );
 }
 
-export function logVerificationStarted(sessionUri: string): Promise<void> {
-  return insertFlowEvent(VERIFICATION_FLOW_EVENT, 'started', sessionUri);
+export function storeCredentialVerificationStartedEvent(
+  sessionUri: string,
+): Promise<void> {
+  return storeCredentialFlowEvent(
+    CREDENTIAL_VERIFICATION_EVENT,
+    'verification-started',
+    sessionUri,
+  );
 }
 
-export function logVerificationSucceeded(
+export function storeCredentialVerificationSucceededEvent(
   sessionUri: string,
   sessionInfo: SessionInfo,
 ): Promise<void> {
-  return insertFlowEvent(
-    VERIFICATION_FLOW_EVENT,
-    'accepted',
+  return storeCredentialFlowEvent(
+    CREDENTIAL_VERIFICATION_EVENT,
+    'verification-succeeded',
     sessionUri,
     sessionInfo,
   );
 }
 
-export function logVerificationFailed(
+export function storeCredentialVerificationFailedEvent(
   sessionUri: string,
   errorMessage: string,
 ): Promise<void> {
-  return insertFlowEvent(
-    VERIFICATION_FLOW_EVENT,
-    'failed',
+  return storeCredentialFlowEvent(
+    CREDENTIAL_VERIFICATION_EVENT,
+    'verification-failed',
     sessionUri,
     undefined,
     errorMessage,

--- a/utils/flow-logger.ts
+++ b/utils/flow-logger.ts
@@ -20,7 +20,8 @@ async function insertFlowEvent(
   sessionInfo?: SessionInfo,
   errorMessage?: string,
 ): Promise<void> {
-  const uri = `${EVENT_URI_BASE}${crypto.randomUUID()}`;
+  const id = crypto.randomUUID();
+  const uri = `${EVENT_URI_BASE}${id}`;
 
   const extraTriples: string[] = [];
   if (sessionInfo) {
@@ -39,9 +40,11 @@ async function insertFlowEvent(
   await updateSudo(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(env.LOG_GRAPH)} {
         ${sparqlEscapeUri(uri)} a ${rdfType} ;
+          mu:uuid ${sparqlEscapeString(id)} ;
           ext:session ${sparqlEscapeUri(sessionUri)} ;
           ext:eventType ${sparqlEscapeString(eventType)} ;
           dct:created ${sparqlEscapeDateTime(new Date())} .

--- a/utils/flow-logger.ts
+++ b/utils/flow-logger.ts
@@ -1,9 +1,9 @@
 import { updateSudo } from '@lblod/mu-auth-sudo';
+import crypto from 'node:crypto';
 import {
   sparqlEscapeDateTime,
   sparqlEscapeString,
   sparqlEscapeUri,
-  uuid,
 } from 'mu';
 import type { SessionInfo } from './credential-format';
 import env from './environment';
@@ -24,7 +24,7 @@ async function insertFlowEvent(
   sessionInfo?: SessionInfo,
   errorMessage?: string,
 ): Promise<void> {
-  const uri = `${EVENT_URI_BASE}${uuid()}`;
+  const uri = `${EVENT_URI_BASE}${crypto.randomUUID()}`;
 
   const extraTriples: string[] = [];
   if (sessionInfo) {

--- a/utils/flow-logger.ts
+++ b/utils/flow-logger.ts
@@ -1,6 +1,10 @@
 import { updateSudo } from '@lblod/mu-auth-sudo';
-import crypto from 'node:crypto';
-import { sparqlEscapeDateTime, sparqlEscapeString, sparqlEscapeUri } from 'mu';
+import {
+  sparqlEscapeDateTime,
+  sparqlEscapeString,
+  sparqlEscapeUri,
+  uuid,
+} from 'mu';
 import type { SessionInfo } from './credential-format';
 import env from './environment';
 
@@ -20,7 +24,7 @@ async function insertFlowEvent(
   sessionInfo?: SessionInfo,
   errorMessage?: string,
 ): Promise<void> {
-  const id = crypto.randomUUID();
+  const id = uuid();
   const uri = `${EVENT_URI_BASE}${id}`;
 
   const extraTriples: string[] = [];

--- a/utils/flow-logger.ts
+++ b/utils/flow-logger.ts
@@ -1,0 +1,109 @@
+import { updateSudo } from '@lblod/mu-auth-sudo';
+import {
+  sparqlEscapeDateTime,
+  sparqlEscapeString,
+  sparqlEscapeUri,
+  uuid,
+} from 'mu';
+import type { SessionInfo } from './credential-format';
+import env from './environment';
+
+const EVENT_URI_BASE = 'http://data.lblod.info/flow-event/';
+
+type FlowEventType = 'ext:IssuanceFlowEvent' | 'ext:VerificationFlowEvent';
+
+async function insertFlowEvent(
+  rdfType: FlowEventType,
+  eventType: string,
+  sessionUri: string,
+  sessionInfo?: SessionInfo,
+  errorMessage?: string,
+): Promise<void> {
+  const uri = `${EVENT_URI_BASE}${uuid()}`;
+
+  const extraTriples: string[] = [];
+  if (sessionInfo) {
+    extraTriples.push(
+      `${sparqlEscapeUri(uri)} ext:account ${sparqlEscapeUri(sessionInfo.accountUri)} .`,
+      `${sparqlEscapeUri(uri)} ext:group ${sparqlEscapeUri(sessionInfo.group)} .`,
+      `${sparqlEscapeUri(uri)} ext:roles ${sparqlEscapeString(sessionInfo.roles)} .`,
+    );
+  }
+  if (errorMessage) {
+    extraTriples.push(
+      `${sparqlEscapeUri(uri)} ext:errorMessage ${sparqlEscapeString(errorMessage)} .`,
+    );
+  }
+
+  await updateSudo(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(env.LOG_GRAPH)} {
+        ${sparqlEscapeUri(uri)} a ${rdfType} ;
+          ext:session ${sparqlEscapeUri(sessionUri)} ;
+          ext:eventType ${sparqlEscapeString(eventType)} ;
+          dct:created ${sparqlEscapeDateTime(new Date())} .
+        ${extraTriples.join('\n        ')}
+      }
+    }
+  `);
+}
+
+export function logIssuanceStarted(sessionUri: string): Promise<void> {
+  return insertFlowEvent('ext:IssuanceFlowEvent', 'started', sessionUri);
+}
+
+export function logIssuanceSucceeded(
+  sessionUri: string,
+  sessionInfo: SessionInfo,
+): Promise<void> {
+  return insertFlowEvent(
+    'ext:IssuanceFlowEvent',
+    'credential-issued',
+    sessionUri,
+    sessionInfo,
+  );
+}
+
+export function logIssuanceFailed(
+  sessionUri: string,
+  errorMessage: string,
+): Promise<void> {
+  return insertFlowEvent(
+    'ext:IssuanceFlowEvent',
+    'failed',
+    sessionUri,
+    undefined,
+    errorMessage,
+  );
+}
+
+export function logVerificationStarted(sessionUri: string): Promise<void> {
+  return insertFlowEvent('ext:VerificationFlowEvent', 'started', sessionUri);
+}
+
+export function logVerificationSucceeded(
+  sessionUri: string,
+  sessionInfo: SessionInfo,
+): Promise<void> {
+  return insertFlowEvent(
+    'ext:VerificationFlowEvent',
+    'accepted',
+    sessionUri,
+    sessionInfo,
+  );
+}
+
+export function logVerificationFailed(
+  sessionUri: string,
+  errorMessage: string,
+): Promise<void> {
+  return insertFlowEvent(
+    'ext:VerificationFlowEvent',
+    'failed',
+    sessionUri,
+    undefined,
+    errorMessage,
+  );
+}

--- a/utils/flow-logger.ts
+++ b/utils/flow-logger.ts
@@ -10,7 +10,12 @@ import env from './environment';
 
 const EVENT_URI_BASE = 'http://data.lblod.info/flow-event/';
 
-type FlowEventType = 'ext:IssuanceFlowEvent' | 'ext:VerificationFlowEvent';
+const ISSUANCE_FLOW_EVENT = 'ext:VCIssuanceFlowEvent' as const;
+const VERIFICATION_FLOW_EVENT = 'ext:VCVerificationFlowEvent' as const;
+
+type FlowEventType =
+  | typeof ISSUANCE_FLOW_EVENT
+  | typeof VERIFICATION_FLOW_EVENT;
 
 async function insertFlowEvent(
   rdfType: FlowEventType,
@@ -51,7 +56,7 @@ async function insertFlowEvent(
 }
 
 export function logIssuanceStarted(sessionUri: string): Promise<void> {
-  return insertFlowEvent('ext:IssuanceFlowEvent', 'started', sessionUri);
+  return insertFlowEvent(ISSUANCE_FLOW_EVENT, 'started', sessionUri);
 }
 
 export function logIssuanceSucceeded(
@@ -59,7 +64,7 @@ export function logIssuanceSucceeded(
   sessionInfo: SessionInfo,
 ): Promise<void> {
   return insertFlowEvent(
-    'ext:IssuanceFlowEvent',
+    ISSUANCE_FLOW_EVENT,
     'credential-issued',
     sessionUri,
     sessionInfo,
@@ -71,7 +76,7 @@ export function logIssuanceFailed(
   errorMessage: string,
 ): Promise<void> {
   return insertFlowEvent(
-    'ext:IssuanceFlowEvent',
+    ISSUANCE_FLOW_EVENT,
     'failed',
     sessionUri,
     undefined,
@@ -80,7 +85,7 @@ export function logIssuanceFailed(
 }
 
 export function logVerificationStarted(sessionUri: string): Promise<void> {
-  return insertFlowEvent('ext:VerificationFlowEvent', 'started', sessionUri);
+  return insertFlowEvent(VERIFICATION_FLOW_EVENT, 'started', sessionUri);
 }
 
 export function logVerificationSucceeded(
@@ -88,7 +93,7 @@ export function logVerificationSucceeded(
   sessionInfo: SessionInfo,
 ): Promise<void> {
   return insertFlowEvent(
-    'ext:VerificationFlowEvent',
+    VERIFICATION_FLOW_EVENT,
     'accepted',
     sessionUri,
     sessionInfo,
@@ -100,7 +105,7 @@ export function logVerificationFailed(
   errorMessage: string,
 ): Promise<void> {
   return insertFlowEvent(
-    'ext:VerificationFlowEvent',
+    VERIFICATION_FLOW_EVENT,
     'failed',
     sessionUri,
     undefined,

--- a/utils/flow-logger.ts
+++ b/utils/flow-logger.ts
@@ -1,10 +1,6 @@
 import { updateSudo } from '@lblod/mu-auth-sudo';
 import crypto from 'node:crypto';
-import {
-  sparqlEscapeDateTime,
-  sparqlEscapeString,
-  sparqlEscapeUri,
-} from 'mu';
+import { sparqlEscapeDateTime, sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import type { SessionInfo } from './credential-format';
 import env from './environment';
 


### PR DESCRIPTION
## Description

The VC issuance (`POST /credential`) and verification (`POST /presentation-response`) flows now insert triples into the triplestore describing events happening during the flow. At the beginning of each flow, a *start* event is inserted. In case something goes wrong during a flow, a *fail* event is inserted. And if the end of a flow is successfully reached, an *end* event is inserted. The `LOG_GRAPH` env var configures in which graph the triples are stored, by default this is `http://mu.semte.ch/graphs/verifiable-credentials/logs`.

For each flow and event type, this is what the triples look like:

### Issuance started

```ttl
<http://data.lblod.info/flow-event/a1b2c3d4>
    a ext:CredentialIssuanceEvent ;
    mu:uuid "a1b2c3d4" ;
    ext:session <http://mu.semte.ch/sessions/original-session-uri> ;
    ext:eventType "issuance-started" ;
    dct:created "2026-06-11T10:00:00.000Z"^^xsd:dateTime .
```

### Issuance failed

```ttl
<http://data.lblod.info/flow-event/a1b2c3d4>
    a ext:CredentialIssuanceEvent ;
    mu:uuid "a1b2c3d4" ;
    ext:session <http://mu.semte.ch/sessions/original-session-uri> ;
    ext:eventType "issuance-failed" ;
    dct:created "2026-06-11T10:00:03.000Z"^^xsd:dateTime ;
    ext:errorMessage "missing_proof" .
```

### Issuance succeeded

```ttl
<http://data.lblod.info/flow-event/e5f6g7h8>
    a ext:CredentialIssuanceEvent ;
    mu:uuid "e5f6g7h8" ;
    ext:session <http://mu.semte.ch/sessions/original-session-uri> ;
    ext:eventType "issuance-succeeded" ;
    dct:created "2026-06-11T10:00:05.000Z"^^xsd:dateTime ;
    ext:account <http://data.lblod.info/accounts/acc-uuid> ;
    ext:group <http://data.lblod.info/organizations/org-uuid> ;
    ext:roles "Decide-gebruiker" .
```

### Verification started

```ttl
<http://data.lblod.info/flow-event/i9j0k1l2>
    a ext:CredentialVerificationEvent ;
    mu:uuid "i9j0k1l2" ;
    ext:session <http://mu.semte.ch/sessions/original-session-uri> ;
    ext:eventType "verification-started" ;
    dct:created "2026-06-11T10:01:00.000Z"^^xsd:dateTime .
```

### Verification failed

```ttl
<http://data.lblod.info/flow-event/m3n4o5p6>
    a ext:CredentialVerificationEvent ;
    mu:uuid "m3n4o5p6" ;
    ext:session <http://mu.semte.ch/sessions/original-session-uri> ;
    ext:eventType "verification-failed" ;
    dct:created "2026-06-11T10:01:02.000Z"^^xsd:dateTime ;
    ext:errorMessage "Credential issuer is not trusted" .
```

### Verification succeeded

```ttl
<http://data.lblod.info/flow-event/m3n4o5p6>
    a ext:CredentialVerificationEvent ;
    mu:uuid "m3n4o5p6" ;
    ext:session <http://mu.semte.ch/sessions/original-session-uri> ;
    ext:eventType "verification-succeeded" ;
    dct:created "2026-06-11T10:01:04.000Z"^^xsd:dateTime ;
    ext:account <http://data.lblod.info/accounts/acc-uuid> ;
    ext:group <http://data.lblod.info/organizations/org-uuid> ;
    ext:roles "Decide-gebruiker" .
```

## How to test

> The feature is temporarily deployed on test, so the following steps assume you use the test server.

> Before *publishing* this PR, the `http://mu.semte.ch/graphs/verifiable-credentials/logs` graph has been cleared so you can have a clean overview.

1. Visit https://yasgui.decide.lblod.info/ and go through the issuance flow, i.e. "Buy access".

2. On the server's triplestore, run the following query to check whether the correct event triples are present:

```sparql
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

SELECT ?created ?uuid ?event ?eventType ?session ?account ?group ?roles ?errorMessage
WHERE {
  GRAPH <http://mu.semte.ch/graphs/verifiable-credentials/logs> {
    ?event a ?eventTypeClass ;
      mu:uuid ?uuid ;
      ext:session ?session ;
      ext:eventType ?eventType ;
      dct:created ?created .

    OPTIONAL { ?event ext:account ?account . }
    OPTIONAL { ?event ext:group ?group . }
    OPTIONAL { ?event ext:roles ?roles . }
    OPTIONAL { ?event ext:errorMessage ?errorMessage . }
  }
}
ORDER BY ?created ?eventType
```

3. Log out again and this time go through the verification flow, i.e. "Scan QR code".

4. On the server's triplestore, run the same query as before and check whether the correct event triples have been added.